### PR TITLE
Add: Makefile to prepare and start the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+prepare:
+	cd ./client/ && npm install
+	cd ./server/ && npm install
+
+start-frontend:
+	cd ./client/ && npm start
+
+start-backend:
+	cd ./server/ && npm start
+
+start:
+	$(MAKE) -j start-backend start-frontend 


### PR DESCRIPTION
#### 🤔 Why?

- To create commands to prepare and run the project fast and simple.

#### 🛠 What I changed:

- `Makefile`: to add the commands.

#### 🚦 Functional Testing Results:

- **Terminal**:

<img width="922" alt="image" src="https://user-images.githubusercontent.com/44406603/191145027-b7ae2d87-a715-46f0-a673-d13f44d9e8ea.png">
<img width="737" alt="image" src="https://user-images.githubusercontent.com/44406603/191145169-4370001b-d16a-493e-9698-ea36c2eb5ee8.png">
<img width="922" alt="image" src="https://user-images.githubusercontent.com/44406603/191145109-35a20765-de5a-4f61-92fb-73c13c005afd.png">